### PR TITLE
COM-80 unselect after clicking off of a pin

### DIFF
--- a/components/MapScreen.tsx
+++ b/components/MapScreen.tsx
@@ -624,14 +624,14 @@ export default function MapScreen({ distanceRadius, selectedReportId, filter = '
                 setTimeout(() => {
                   const mr = markerRefs.current[report.reportid];
                   if (mr && mr.showCallout) {
-                    try { mr.showCallout(); } catch (e) {}
+                    try { mr.showCallout(); } catch (e) { console.error("Error calling showCallout on marker:", e); }
                   }
                 }, 0);
               } else {
                 // If deselecting via marker tap, hide its callout immediately
                 const mr = markerRefs.current[report.reportid];
                 if (mr && mr.hideCallout) {
-                  try { mr.hideCallout(); } catch (e) {}
+                  try { mr.hideCallout(); } catch (e) { console.error("Error calling hideCallout on marker:", e); }
                 }
               }
 


### PR DESCRIPTION
PR comment — instant pin highlight + click-off to unselect
Summary

Make marker selection/deselection instant and predictable:
Clicking a pin highlights it and shows the pin detail immediately.
Clicking anywhere else on the map hides the pin detail and un-highlights immediately (no delay/animation).