### PR TITLE
COM-93: Fix Bug Where App Crashes When You Filter Too Fast

### DIFF
--- a/app/home.tsx
+++ b/app/home.tsx
@@ -18,7 +18,11 @@ import { MARKER_COLORS } from '@/constants/Markers';
 
 export default function Home() {
   const insets = useSafeAreaInsets();
+  // UI-selected filter (instant for button highlight)
   const [selectedFilter, setSelectedFilter] = useState<'all' | 'hazard' | 'event' | 'lost' | 'found'>('all');
+  // Debounced/applied filter used for the Map to reduce rapid mount/unmount thrash
+  const [appliedFilter, setAppliedFilter] = useState<'all' | 'hazard' | 'event' | 'lost' | 'found'>('all');
+  const filterDebounceRef = React.useRef<number | null>(null);
   const filterScrollRef = React.useRef<ScrollView | null>(null);
   const scrollOffsetRef = React.useRef<number>(0);
 
@@ -30,12 +34,34 @@ export default function Home() {
   };
 
   const handleFilterPress = (filterValue: 'all' | 'hazard' | 'event' | 'lost' | 'found') => {
+    // Update UI state immediately for responsiveness
     setSelectedFilter(filterValue);
+
+    // Keep filter bar scroll position stable
     const offset = scrollOffsetRef.current;
     scrollToOffset(offset);
     requestAnimationFrame(() => scrollToOffset(offset));
     setTimeout(() => scrollToOffset(offset), 0);
+
+    // Debounce applying the filter to the map to avoid rapid marker churn/crashes
+    if (filterDebounceRef.current) {
+      clearTimeout(filterDebounceRef.current as unknown as number);
+      filterDebounceRef.current = null;
+    }
+    filterDebounceRef.current = setTimeout(() => {
+      setAppliedFilter(filterValue);
+    }, 200) as unknown as number;
   };
+
+  // Cleanup any pending debounce on unmount
+  useEffect(() => {
+    return () => {
+      if (filterDebounceRef.current) {
+        clearTimeout(filterDebounceRef.current as unknown as number);
+        filterDebounceRef.current = null;
+      }
+    };
+  }, []);
 
   const FilterBar = () => (
     <ScrollView
@@ -501,7 +527,7 @@ export default function Home() {
       <MapScreen 
         distanceRadius={distanceRadius} 
         selectedReportId={selectedReportId ? Number(selectedReportId) : undefined} 
-      filter={selectedFilter} />
+      filter={appliedFilter} />
 
       {/* Overlay to close speed dial when expanded */}
       {isFabExpanded && (

--- a/components/MapScreen.tsx
+++ b/components/MapScreen.tsx
@@ -61,6 +61,18 @@ export default function MapScreen({ distanceRadius, selectedReportId, filter = '
     };
   }, []);
 
+  // When the filter changes, clear any selected report to prevent callout/ref races
+  useEffect(() => {
+    if (selectedReport) {
+      // best-effort hide of previous callout
+      const mr = markerRefs.current[selectedReport.reportid];
+      if (mr && (mr as any).hideCallout) {
+        try { (mr as any).hideCallout(); } catch {}
+      }
+    }
+    setSelectedReport(null);
+  }, [filter]);
+
   // Fetch user location
   useEffect(() => {
     let subscription: Location.LocationSubscription;


### PR DESCRIPTION
This pull request improves the filtering experience on the map screen by introducing a debounced filter application, which enhances UI responsiveness and prevents performance issues caused by rapid filter changes. The main changes separate the immediate UI feedback from the actual filter applied to the map, and ensure proper cleanup of debounce timers. Additionally, the map now clears any selected report when the filter changes to avoid UI inconsistencies.

**Filter application improvements:**

* Introduced a new state variable `appliedFilter` in `home.tsx` to separate the instant UI-selected filter from the debounced filter actually applied to the map, reducing rapid marker churn and potential crashes.
* Updated the `handleFilterPress` function in `home.tsx` to debounce the application of the filter, ensuring that the map only updates after a short delay, and added cleanup logic for the debounce timer on component unmount.
* Changed the `filter` prop passed to `MapScreen` from `selectedFilter` to `appliedFilter` in `home.tsx`, so the map only updates when the debounced filter changes.

**Map marker and UI consistency:**

* Added a `useEffect` in `MapScreen.tsx` to clear any selected report and hide its callout when the filter changes, preventing callout or reference issues when the displayed markers change.